### PR TITLE
docs: move examples [#48]

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -8,12 +8,16 @@
       "thelper",
       "paralleltest",
       "ireturn",
-      "gomnd"
+      "gomnd",
+      "nolintlint"
     ]
   },
   "linters-settings": {
     "goimports": {
       "local-prefixes": "github.com/hedhyw/rex/"
+    },
+    "nolintlint": {
+      "allow-leading-space": false
     },
     "revive": {}
   }

--- a/.golangci.json
+++ b/.golangci.json
@@ -16,9 +16,6 @@
     "goimports": {
       "local-prefixes": "github.com/hedhyw/rex/"
     },
-    "nolintlint": {
-      "allow-leading-space": false
-    },
     "revive": {}
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOLANG_CI_LINT_VER:=v1.46.2
+GOLANG_CI_LINT_VER:=v1.50.0
 COVER_PACKAGES=${shell go list ./... | grep -Ev 'test' | tr '\n' ','}
 
 all: lint test

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - **[Why?](#why)**
 - **[FAQ](#faq)**
 - **[Documentation](_docs/library.md)**
-- **[Examples](pkg/examples_test.go)**
+- **[Examples](pkg/rex/examples_test.go)**
 - **[License](#license)**
 
 ## Why?

--- a/_docs/examples.md
+++ b/_docs/examples.md
@@ -79,4 +79,4 @@ submatches := re.FindAllStringSubmatch(text, -1)
 
 #### More examples
 
-More examples can be found here: [examples_test.go](examples_test.go).
+More examples can be found here: [examples_test.go](../pkg/rex/examples_test.go).

--- a/pkg/dialect/base/helper_number.go
+++ b/pkg/dialect/base/helper_number.go
@@ -22,10 +22,10 @@ type NumberRange struct {
 //
 // It doesn't match leading zeros. If you want to match them, use:
 //
-//   Group.NonCaptured(
-//     Chars.Single('0').Repeat().ZeroOrMore(),
-//     Helper.NumberRange(0, 99),
-//   )
+//	Group.NonCaptured(
+//	  Chars.Single('0').Repeat().ZeroOrMore(),
+//	  Helper.NumberRange(0, 99),
+//	)
 func (h HelperDialect) NumberRange(from int32, to int32) NumberRange {
 	return NumberRange{
 		initialFrom: int64(from),

--- a/pkg/dialect/base/helper_phone.go
+++ b/pkg/dialect/base/helper_phone.go
@@ -7,9 +7,10 @@ import (
 // Phone contains composite of different phone patterns: E.164, E.123.
 //
 // Examples:
-//   +15555555
-//   (607) 123 4567
-//   +22 607 123 4567
+//
+//	+15555555
+//	(607) 123 4567
+//	+22 607 123 4567
 func (h HelperDialect) Phone() dialect.Token {
 	return Group.Composite(
 		h.PhoneE164(),
@@ -43,8 +44,9 @@ func (HelperDialect) PhoneE164() dialect.Token {
 // It combines international and national formats.
 //
 // Examples:
-//   (607) 123 4567
-//   +22 607 123 4567
+//
+//	(607) 123 4567
+//	+22 607 123 4567
 func (h HelperDialect) PhoneE123() dialect.Token {
 	return Group.Composite(
 		h.PhoneNationalE123(),

--- a/pkg/dialect/base/helper_web.go
+++ b/pkg/dialect/base/helper_web.go
@@ -54,10 +54,10 @@ func (HelperDialect) HostnameRFC1123() dialect.Token {
 // Hostname is validated considering RFC-1123.
 //
 // Localpart is unquoted, and may use any of these ASCII characters:
-// - uppercase and lowercase Latin letters A to Z and a to z, digits 0 to 9
-// - printable characters !#$%&'*+-/=?^_`{|}~
-// - dot ., provided that it is not the first or last character and provided
-//   also that it does not appear consecutively (e.g., John..Doe@example.com is not allowed).
+//   - uppercase and lowercase Latin letters A to Z and a to z, digits 0 to 9
+//   - printable characters !#$%&'*+-/=?^_`{|}~
+//   - dot ., provided that it is not the first or last character and provided
+//     also that it does not appear consecutively (e.g., John..Doe@example.com is not allowed).
 func (h HelperDialect) Email() dialect.Token {
 	localCharsWithoutDot := Common.Class(
 		Chars.Alphanumeric(),

--- a/pkg/dialect/base/raw.go
+++ b/pkg/dialect/base/raw.go
@@ -40,9 +40,12 @@ func (rt RawToken) WriteTo(w dialect.StringByteWriter) (n int, err error) {
 // backslash '\#' or it is not in the character class '[#]'.
 //
 // This input:
-//   .+\#[#] # comment
+//
+//	.+\#[#] # comment
+//
 // Will be converted to:
-//   .+\#[#]
+//
+//	.+\#[#]
 func removeComment(val string) string {
 	var (
 		backslash      bool

--- a/pkg/rex/examples_test.go
+++ b/pkg/rex/examples_test.go
@@ -1,4 +1,4 @@
-// nolint: lll // Generated regular expression can be long.
+// nolint: lll,nosnakecase // Generated regular expression can be long.
 package rex_test
 
 import (
@@ -12,7 +12,7 @@ import (
 func Example_basicMethods() {
 	rexRe := rex.New(rex.Chars.Any().Repeat().ZeroOrMore())
 
-	// Use Compile if you spcify dynamic arguments.
+	// Use Compile if you specify dynamic arguments.
 	re, err := rexRe.Compile()
 	if err != nil {
 		log.Fatal(err)
@@ -20,7 +20,7 @@ func Example_basicMethods() {
 
 	fmt.Println(`re.MatchString("a"):`, re.MatchString("a"))
 
-	// Use MustCompile if you don't speicfy dynamic arguments.
+	// Use MustCompile if you don't specify dynamic arguments.
 	re = rexRe.MustCompile()
 	fmt.Println(`re.MatchString("a"):`, re.MatchString("a"))
 


### PR DESCRIPTION
- Move examples to one directory deeper.
- Update `golangci-lint`.